### PR TITLE
removed aggressive check for BUILD_PYTHON

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,7 +6,7 @@ every change, see the Git log.
 
 Latest
 ------
-* tbd
+* Patch: Moved the check for the BUILD_PYTHON variable to the build step.
 
 9.0.0
 -----

--- a/wscript
+++ b/wscript
@@ -42,10 +42,6 @@ def configure(conf):
 
     conf.load("wurf_common_tools")
 
-    # Ensure that Python is configured properly
-    if not conf.env['BUILD_PYTHON']:
-        conf.fatal('Python was not configured properly')
-
 
 def build(bld):
 

--- a/wscript
+++ b/wscript
@@ -45,6 +45,11 @@ def configure(conf):
 
 def build(bld):
 
+    # Ensure that Python was configured properly in the configure step of
+    # the boost wscript (boost-python needs to be configured in the boost repo)
+    if not bld.env['BUILD_PYTHON']:
+        bld.fatal('Python was not configured properly')
+
     bld.load("wurf_common_tools")
 
     bld.env.append_unique(


### PR DESCRIPTION
I could not build kodo-python as a dependency with this code active. Now I can.